### PR TITLE
Fix attachment download in Salesforce file replicator

### DIFF
--- a/main.py
+++ b/main.py
@@ -86,9 +86,9 @@ def main():
                     error_writer.writerow([record_id, '', '', '', '', 'error', 'ContentVersion not found'])
                     continue
                 filename = f"{version.get('Title')}.{version.get('FileExtension')}" if version.get('FileExtension') else version.get('Title')
-                data = version.get('VersionData')
+                data = client.download_content_version_data(version)
                 try:
-                    saved_path = save_file(output_dir / record_id, filename, data if isinstance(data, bytes) else data.encode())
+                    saved_path = save_file(output_dir / record_id, filename, data)
                     success_writer.writerow([
                         record_id,
                         version.get('Id'),

--- a/salesforce_client.py
+++ b/salesforce_client.py
@@ -35,3 +35,18 @@ class SalesforceClient:
         )
         records = self.sf.query_all(soql)["records"]
         return records[0] if records else None
+
+    def download_content_version_data(self, version: Dict) -> bytes:
+        """Download the binary data for the given ContentVersion record."""
+        data = version.get("VersionData")
+        if self.test_mode:
+            if isinstance(data, bytes):
+                return data
+            return data.encode() if data else b""
+        if not isinstance(data, str):
+            # When using real API this should be a URL string
+            return b""
+        url = self.sf.base_url + data
+        response = self.sf.session.get(url)
+        response.raise_for_status()
+        return response.content


### PR DESCRIPTION
## Summary
- handle ContentVersion download by following VersionData URL
- use new download method when saving files

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_b_687f124b38dc8321a479b17dd9555988